### PR TITLE
Exclude .bin files from settings export

### DIFF
--- a/main/handlers/ui-handlers.ts
+++ b/main/handlers/ui-handlers.ts
@@ -12,7 +12,6 @@ export function registerUiHandlers(win: BrowserWindow) {
 
 	ipcMain.handle(IPC_CHANNELS.SAVE_SETTINGS_ZIP, async (event, filePath) => {
 		const settingsDir = path.join(app.getPath('userData'), 'data');
-		const credentialsFilePath = "osu-credentials.bin";
 
 		return new Promise<void>((resolve, reject) => {
 			const output = fs.createWriteStream(filePath);
@@ -25,7 +24,7 @@ export function registerUiHandlers(win: BrowserWindow) {
 
 			archive.glob('**/*', {
 				cwd: settingsDir,
-				ignore: [credentialsFilePath]
+				ignore: ['**/*.bin']
 			});
 
 			archive.finalize();


### PR DESCRIPTION
Update settings export to exclude all `.bin` files instead of a single static file