### PR TITLE
Switch chat container order

### DIFF
--- a/src/app/modules/irc/components/irc-chat-container/irc-chat-container.component.html
+++ b/src/app/modules/irc/components/irc-chat-container/irc-chat-container.component.html
@@ -7,7 +7,7 @@
 		/>
 	</div>
 
-	<div class="chat-container" [style.--top-height]="topHeight + '%'">
+	<div class="chat-container" [style.--top-height]="topHeight + '%'" [class.switch-containers]="switchChatContainers$ | async">
 		<ng-container *ngIf="selectedChannel?.name.startsWith('#mp_') && (splitBanchoBotMessages$ | async) as splitBanchoBotMessages">
 			<cdk-virtual-scroll-viewport #banchoBotVirtualScroller class="messages banchobot" itemSize="50" *ngIf="splitBanchoBotMessages == true">
 				<div class="chat" *ngFor="let chat of banchoBotChats">

--- a/src/app/modules/irc/components/irc-chat-container/irc-chat-container.component.scss
+++ b/src/app/modules/irc/components/irc-chat-container/irc-chat-container.component.scss
@@ -39,6 +39,8 @@ $url-hover-background-color: rgba(61, 184, 240, 0.2);
 	}
 
 	.chat-container {
+		display: flex;
+		flex-direction: column;
 		flex: 1;
 
 		--top-height: 30%;
@@ -279,6 +281,10 @@ $url-hover-background-color: rgba(61, 184, 240, 0.2);
 				linear-gradient(rgba(255, 255, 255, 0.02) 1px, transparent 1px),
 				linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
 			background-size: 36px 36px;
+		}
+
+		&.switch-containers {
+			flex-direction: column-reverse;
 		}
 	}
 

--- a/src/app/modules/irc/components/irc-chat-container/irc-chat-container.component.ts
+++ b/src/app/modules/irc/components/irc-chat-container/irc-chat-container.component.ts
@@ -28,6 +28,7 @@ export class IrcChatContainerComponent implements OnInit {
 	@Output() adjustScoreEmitter = new EventEmitter<{ team: number, mouseClick: string }>();
 
 	splitBanchoBotMessages$ = this.genericService.getSplitBanchoBotMessagesStatus();
+	switchChatContainers$ = this.genericService.getChatContainerSwitchStatus();
 	topHeight = 30;
 
 	private resizing = false;
@@ -116,6 +117,10 @@ export class IrcChatContainerComponent implements OnInit {
 			const rect = container.getBoundingClientRect();
 			const offsetY = this.latestEvent.clientY - rect.top;
 			let percentage = (offsetY / rect.height) * 100;
+
+			if (this.switchChatContainers$.value) {
+				percentage = 100 - percentage;
+			}
 
 			percentage = Math.max(10, Math.min(90, percentage));
 

--- a/src/app/modules/settings/components/settings/settings.component.ts
+++ b/src/app/modules/settings/components/settings/settings.component.ts
@@ -23,6 +23,7 @@ export class SettingsComponent implements OnInit {
 	axsMenuStatus: boolean;
 	showIncorrectSlotStatus: boolean;
 	splitBanchoBotMessages: boolean;
+	chatContainerSwitched: boolean;
 	showAllShortcutsStatus: boolean;
 
 	generalOptions: OptionsMenu[] = [
@@ -32,6 +33,7 @@ export class SettingsComponent implements OnInit {
 	ircOptions: OptionsMenu[] = [
 		{ header: 'Show incorrect slot warning', description: 'Toggle whether to show a warning when a player is in an incorrect slot. This is shown when <code>!mp settings</code> is used', action: () => this.toggleShowIncorrectSlot(), slideToggle: true, slideToggleValue: this.genericService.getShowIncorrectSlotStatus() },
 		{ header: 'Split BanchoBot messages', description: 'Toggle whether to split BanchoBot messages into its own chat container', action: () => this.toggleSplitBanchoBotMessages(), slideToggle: true, slideToggleValue: this.genericService.getSplitBanchoBotMessagesStatus() },
+		{ header: 'Switch chat containers', description: 'Toggle whether to switch the chat containers, default is BanchoBot container on top, normal chat container on the bottom. When enabled, the normal chat container will be on top and the BanchoBot container will be on the bottom.', action: () => this.toggleChatContainerSwitch(), slideToggle: true, slideToggleValue: this.genericService.getChatContainerSwitchStatus() },
 		{ header: 'Display all shortcut commands without scrollbar', description: 'Toggle whether to display all shortcut commands in the shortcuts menu without a scrollbar. These are the buttons above the send message input on the IRC page', action: () => this.toggleShowAllShortcuts(), slideToggle: true, slideToggleValue: this.genericService.getShowAllShortcutsStatus() }
 	];
 
@@ -69,6 +71,10 @@ export class SettingsComponent implements OnInit {
 
 		this.genericService.getSplitBanchoBotMessagesStatus().subscribe(status => {
 			this.splitBanchoBotMessages = status;
+		});
+
+		this.genericService.getChatContainerSwitchStatus().subscribe(status => {
+			this.chatContainerSwitched = status;
 		});
 
 		this.genericService.getShowAllShortcutsStatus().subscribe(status => {
@@ -170,7 +176,12 @@ export class SettingsComponent implements OnInit {
 		this.genericService.setSplitBanchoBotMessages(this.splitBanchoBotMessages);
 	}
 
-	updateWebhookCustomization() {
+	toggleChatContainerSwitch(): void {
+		this.chatContainerSwitched = !this.chatContainerSwitched;
+		this.genericService.toggleChatContainerSwitch(this.chatContainerSwitched);
+	}
+
+	updateWebhookCustomization(): void {
 		this.webhookService.updateWebhookCustomization(this.webhookAuthorImage, this.webhookAuthorName, this.webhookBottomImage, this.webhookFooterIconUrl, this.webhookFooterText);
 		this.toastService.addToast(`Successfully updated your personal webhook customizations.`);
 	}

--- a/src/app/services/generic.service.ts
+++ b/src/app/services/generic.service.ts
@@ -9,6 +9,7 @@ export class GenericService {
 	private showAxSMenu$: BehaviorSubject<boolean>;
 	private showIncorrectSlot$: BehaviorSubject<boolean>;
 	private splitBanchoBotMessages$: BehaviorSubject<boolean>;
+	private chatContainerSwitched$: BehaviorSubject<boolean>;
 	private banchoChatContainerHeight$: BehaviorSubject<number>;
 	private showAllShortcuts$: BehaviorSubject<boolean>;
 
@@ -18,6 +19,7 @@ export class GenericService {
 				this.showAxSMenu$.next(settings.showAxs);
 				this.showIncorrectSlot$.next(settings.showIncorrectSlot);
 				this.splitBanchoBotMessages$.next(settings.splitBanchoBotMessages);
+				this.chatContainerSwitched$.next(settings.chatContainerSwitched);
 				this.banchoChatContainerHeight$.next(settings.banchoChatContainerHeight);
 				this.showAllShortcuts$.next(settings.showAllShortcuts);
 			}
@@ -26,6 +28,7 @@ export class GenericService {
 		this.showAxSMenu$ = new BehaviorSubject(false);
 		this.showIncorrectSlot$ = new BehaviorSubject(true);
 		this.splitBanchoBotMessages$ = new BehaviorSubject(false);
+		this.chatContainerSwitched$ = new BehaviorSubject(false);
 		this.banchoChatContainerHeight$ = new BehaviorSubject(30);
 		this.showAllShortcuts$ = new BehaviorSubject(false);
 	}
@@ -79,6 +82,23 @@ export class GenericService {
 	 */
 	getSplitBanchoBotMessagesStatus(): BehaviorSubject<boolean> {
 		return this.splitBanchoBotMessages$;
+	}
+
+	/**
+	 * Get the status of switching chat containers
+	 */
+	getChatContainerSwitchStatus(): BehaviorSubject<boolean> {
+		return this.chatContainerSwitched$;
+	}
+
+	/**
+	 * Set the status of switching chat containers
+	 *
+	 * @param enabled the status of switching chat containers
+	 */
+	toggleChatContainerSwitch(enabled: boolean): void {
+		this.chatContainerSwitched$.next(enabled);
+		this.settingsStore.set('chatContainerSwitched', enabled);
 	}
 
 	/**

--- a/src/app/services/storage/settings-store.service.ts
+++ b/src/app/services/storage/settings-store.service.ts
@@ -8,6 +8,7 @@ interface AppSettings {
 	showAxs: boolean;
 	showIncorrectSlot: boolean;
 	splitBanchoBotMessages: boolean;
+	chatContainerSwitched: boolean;
 	banchoChatContainerHeight: number;
 	showAllShortcuts: boolean;
 	[key: string]: any;
@@ -18,6 +19,7 @@ const DEFAULT_SETTINGS: AppSettings = {
 	showAxs: false,
 	showIncorrectSlot: true,
 	splitBanchoBotMessages: false,
+	chatContainerSwitched: false,
 	banchoChatContainerHeight: 30,
 	showAllShortcuts: false
 };


### PR DESCRIPTION
Implement the option to switch the chat container order when "Split BanchoBot messages" is enabled. 
Default order is BanchoBot messages on top, regular messages on the bottom. When option is enabled, BanchoBot is at the bottom instead.