### PR TITLE
Change accuracy based on beatmap gamemode

### DIFF
--- a/src/app/services/wy-multiplayer-lobbies.service.ts
+++ b/src/app/services/wy-multiplayer-lobbies.service.ts
@@ -276,6 +276,11 @@ export class WyMultiplayerLobbiesService {
 						}
 					}
 
+					// Apply game mode specific accuracy if beatmap has a gamemode attached to it
+					if (foundModBracketBeatmap && foundModBracketBeatmap.gamemodeId != null) {
+						newMultiplayerDataUser.accuracy = Calculations.getAccuracyOfScore(currentScore, foundModBracketBeatmap.gamemodeId);
+					}
+
 					multiplayerData.addPlayer(newMultiplayerDataUser);
 				}
 


### PR DESCRIPTION
Changes accuracy calculation to take into account the gamemode the beatmap is set to. Specifically used for "All modes" tournaments, where you can assign a gamemode to a specific beatmap.