### PR TITLE
Participant import change

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,6 +34,7 @@ import { UpdateMatchResultsDialogComponent } from './components/dialogs/update-m
 import { DeleteLobbiesDialogComponent } from './components/dialogs/delete-lobbies-dialog/delete-lobbies-dialog.component';
 import { NewUpdateDialogComponent } from './components/dialogs/new-update-dialog/new-update-dialog.component';
 import { ResetIrcLayoutDialogComponent } from './components/dialogs/reset-irc-layout-dialog/reset-irc-layout-dialog.component';
+import { ImportWybinParticipantsDialogComponent } from './components/dialogs/import-wybin-participants-dialog/import-wybin-participants-dialog.component';
 
 export function initStorage(storageDriver: StorageDriverService) {
 	return () => storageDriver.init();
@@ -67,7 +68,8 @@ export function initStorage(storageDriver: StorageDriverService) {
 		DataMigrationDialogComponent,
 		UpdateMatchResultsDialogComponent,
 		NewUpdateDialogComponent,
-		ResetIrcLayoutDialogComponent
+		ResetIrcLayoutDialogComponent,
+		ImportWybinParticipantsDialogComponent
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/components/dialogs/import-wybin-participants-dialog/import-wybin-participants-dialog.component.html
+++ b/src/app/components/dialogs/import-wybin-participants-dialog/import-wybin-participants-dialog.component.html
@@ -1,0 +1,12 @@
+<h2 mat-dialog-title>Import {{ data.type }}</h2>
+
+<mat-dialog-content class="mat-typography">
+	Importing {{ data.type }} from wyBin will remove all existing {{ data.type }} and replace them with the imported {{ data.type }}.
+	<p></p>
+	Are you sure you want to continue?
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+	<button mat-button [mat-dialog-close]="null">cancel</button>
+	<button mat-button [mat-dialog-close]="true" color="primary">import</button>
+</mat-dialog-actions>

--- a/src/app/components/dialogs/import-wybin-participants-dialog/import-wybin-participants-dialog.component.spec.ts
+++ b/src/app/components/dialogs/import-wybin-participants-dialog/import-wybin-participants-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ImportWybinParticipantsDialogComponent } from './import-wybin-participants-dialog.component';
+
+describe('ImportWybinParticipantsDialogComponent', () => {
+	let component: ImportWybinParticipantsDialogComponent;
+	let fixture: ComponentFixture<ImportWybinParticipantsDialogComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [ImportWybinParticipantsDialogComponent]
+		})
+			.compileComponents();
+
+		fixture = TestBed.createComponent(ImportWybinParticipantsDialogComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/components/dialogs/import-wybin-participants-dialog/import-wybin-participants-dialog.component.ts
+++ b/src/app/components/dialogs/import-wybin-participants-dialog/import-wybin-participants-dialog.component.ts
@@ -1,0 +1,11 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+	selector: 'app-import-wybin-participants-dialog',
+	templateUrl: './import-wybin-participants-dialog.component.html',
+	styleUrl: './import-wybin-participants-dialog.component.scss'
+})
+export class ImportWybinParticipantsDialogComponent {
+	constructor(@Inject(MAT_DIALOG_DATA) public data: { type: 'players' | 'teams' }) { }
+}

--- a/src/app/modules/tournament-management/pages/tournament/tournament-participants/tournament-participants.component.ts
+++ b/src/app/modules/tournament-management/pages/tournament/tournament-participants/tournament-participants.component.ts
@@ -10,6 +10,7 @@ import { ToastService } from 'app/services/toast.service';
 import { TournamentService } from 'app/services/tournament.service';
 import { TournamentEditStateService } from '../../../services/tournament-edit-state.service';
 import { debounceTime, filter } from 'rxjs';
+import { ImportWybinParticipantsDialogComponent } from '../../../../../components/dialogs/import-wybin-participants-dialog/import-wybin-participants-dialog.component';
 
 @Component({
 	selector: 'app-tournament-participants',
@@ -250,67 +251,87 @@ export class TournamentParticipantsComponent implements OnInit {
 	}
 
 	importWyBinPlayers(): void {
-		this.importingFromWyBin = true;
-
-		this.initializeForm();
-
-		this.tournamentService.getWyBinTournamentPlayers(this.tournament.wyBinTournamentId).subscribe((players: any) => {
-			const existingUserIds = new Set(
-				this.players.controls
-					.map(ctrl => ctrl.get('userId')?.value)
-					.filter(v => v != null)
-			);
-
-			for (const player of players) {
-				if (existingUserIds.has(player.user.userOsu.id)) {
-					continue;
-				}
-
-				this.players.push(this.createPlayerGroup(null, player.user.username, player.user.userOsu.id));
+		const dialogRef = this.dialog.open(ImportWybinParticipantsDialogComponent, {
+			data: {
+				type: 'players'
 			}
+		});
 
-			this.importingFromWyBin = false;
+		dialogRef.afterClosed().subscribe(result => {
+			if (result != null) {
+				this.importingFromWyBin = true;
+
+				this.initializeForm();
+
+				this.tournamentService.getWyBinTournamentPlayers(this.tournament.wyBinTournamentId).subscribe((players: any) => {
+					const existingUserIds = new Set(
+						this.players.controls
+							.map(ctrl => ctrl.get('userId')?.value)
+							.filter(v => v != null)
+					);
+
+					for (const player of players) {
+						if (existingUserIds.has(player.user.userOsu.id)) {
+							continue;
+						}
+
+						this.players.push(this.createPlayerGroup(null, player.user.username, player.user.userOsu.id));
+					}
+
+					this.importingFromWyBin = false;
+				});
+			}
 		});
 	}
 
 	importWyBinTeams(): void {
-		this.importingFromWyBin = true;
-
-		this.initializeForm();
-
-		this.tournamentService.getWyBinTournamentTeams(this.tournament.wyBinTournamentId).subscribe((teams: any) => {
-			const existingUserIds = new Set(
-				this.teams.controls
-					.map(ctrl => ctrl.get('name')?.value)
-					.filter(v => v != null)
-			);
-
-			for (const team of teams) {
-				if (existingUserIds.has(team.name)) {
-					continue;
-				}
-
-				const newTeam = new WyTeam({
-					name: team.name,
-					index: this.tournament.teamIndex,
-					collapsed: true
-				});
-
-				this.tournament.teamIndex++;
-
-				for (const teamMember of team.teamMembers) {
-					const newPlayer = new WyTeamPlayer({
-						name: teamMember.user.username,
-						userId: teamMember.user.userOsu.id
-					});
-
-					newTeam.players.push(newPlayer);
-				}
-
-				this.teams.push(this.createTeamGroup(newTeam));
+		const dialogRef = this.dialog.open(ImportWybinParticipantsDialogComponent, {
+			data: {
+				type: 'teams'
 			}
+		});
 
-			this.importingFromWyBin = false;
+		dialogRef.afterClosed().subscribe(result => {
+			if (result != null) {
+				this.importingFromWyBin = true;
+
+				this.initializeForm();
+
+				this.tournamentService.getWyBinTournamentTeams(this.tournament.wyBinTournamentId).subscribe((teams: any) => {
+					const existingUserIds = new Set(
+						this.teams.controls
+							.map(ctrl => ctrl.get('name')?.value)
+							.filter(v => v != null)
+					);
+
+					for (const team of teams) {
+						if (existingUserIds.has(team.name)) {
+							continue;
+						}
+
+						const newTeam = new WyTeam({
+							name: team.name,
+							index: this.tournament.teamIndex,
+							collapsed: true
+						});
+
+						this.tournament.teamIndex++;
+
+						for (const teamMember of team.teamMembers) {
+							const newPlayer = new WyTeamPlayer({
+								name: teamMember.user.username,
+								userId: teamMember.user.userOsu.id
+							});
+
+							newTeam.players.push(newPlayer);
+						}
+
+						this.teams.push(this.createTeamGroup(newTeam));
+					}
+
+					this.importingFromWyBin = false;
+				});
+			}
 		});
 	}
 

--- a/src/app/modules/tournament-management/pages/tournament/tournament-participants/tournament-participants.component.ts
+++ b/src/app/modules/tournament-management/pages/tournament/tournament-participants/tournament-participants.component.ts
@@ -49,6 +49,10 @@ export class TournamentParticipantsComponent implements OnInit {
 			.subscribe(tournament => {
 				this.tournament = tournament;
 
+				if (this.initialized == true) {
+					return;
+				}
+
 				if (tournament.isSoloTournament()) {
 					if (this.players.length === 0) {
 						const formArray = new FormArray(
@@ -96,6 +100,8 @@ export class TournamentParticipantsComponent implements OnInit {
 						});
 					}
 				}
+
+				this.initialized = true;
 			});
 
 		this.form.valueChanges

--- a/src/app/modules/tournament-management/pages/tournament/tournament-participants/tournament-participants.component.ts
+++ b/src/app/modules/tournament-management/pages/tournament/tournament-participants/tournament-participants.component.ts
@@ -28,6 +28,7 @@ export class TournamentParticipantsComponent implements OnInit {
 	teamFilter: string;
 
 	importingFromWyBin: boolean;
+	private initialized = false;
 
 	constructor(
 		private dialog: MatDialog,
@@ -37,10 +38,7 @@ export class TournamentParticipantsComponent implements OnInit {
 	) {
 		this.importingFromWyBin = false;
 
-		this.form = new FormGroup({
-			players: new FormArray([]),
-			teams: new FormArray([])
-		});
+		this.initializeForm();
 
 		this.collapsedState = new WeakMap();
 	}
@@ -248,6 +246,8 @@ export class TournamentParticipantsComponent implements OnInit {
 	importWyBinPlayers(): void {
 		this.importingFromWyBin = true;
 
+		this.initializeForm();
+
 		this.tournamentService.getWyBinTournamentPlayers(this.tournament.wyBinTournamentId).subscribe((players: any) => {
 			const existingUserIds = new Set(
 				this.players.controls
@@ -269,6 +269,8 @@ export class TournamentParticipantsComponent implements OnInit {
 
 	importWyBinTeams(): void {
 		this.importingFromWyBin = true;
+
+		this.initializeForm();
 
 		this.tournamentService.getWyBinTournamentTeams(this.tournament.wyBinTournamentId).subscribe((teams: any) => {
 			const existingUserIds = new Set(
@@ -327,6 +329,13 @@ export class TournamentParticipantsComponent implements OnInit {
 			id: new FormControl(team?.id || null),
 			name: new FormControl(team?.name || '', Validators.required),
 			players: playersFormArray
+		});
+	}
+
+	private initializeForm() {
+		this.form = new FormGroup({
+			players: new FormArray([]),
+			teams: new FormArray([])
 		});
 	}
 }


### PR DESCRIPTION
- Removes all existing players/teams from the tournament and replaces them with the imported players/teams from wyBin. A warning will be shown when you import them
- Fixes an issue where team/player names wouldn't update after the first change