### PR TITLE
Fix keyboard zoom in/out shortcut

### DIFF
--- a/main/services/window-manager.ts
+++ b/main/services/window-manager.ts
@@ -4,6 +4,8 @@ import * as path from "path";
 
 export class WindowManager {
 	win: BrowserWindow | null = null;
+	ZOOM_MIN = -5;
+	ZOOM_MAX = 5;
 
 	constructor(private serve: boolean) { }
 
@@ -44,6 +46,50 @@ export class WindowManager {
 			this.win.loadURL(url);
 		}
 
+		this.win.webContents.on('before-input-event', (event, input) => {
+			if (input.type !== 'keyDown') {
+				return;
+			}
+
+			if (!input.control && !input.meta) {
+				return;
+			}
+
+			switch (input.code) {
+				case 'Equal':
+					this.applyZoom(this.win, 0.5);
+					break;
+
+				case 'Minus':
+					this.applyZoom(this.win, -0.5);
+					break;
+
+				case 'Digit0':
+					this.applyZoom(this.win, 0);
+					break;
+				default:
+					return;
+			}
+
+			event.preventDefault();
+		});
+
 		return this.win;
+	}
+
+	private applyZoom(window: BrowserWindow | null, zoomLevel: number) {
+		if (window == null) {
+			return;
+		}
+
+		const win = window?.webContents;
+
+		if (zoomLevel === 0) {
+			win?.setZoomLevel(0);
+		}
+		else {
+			const next = win?.zoomLevel + zoomLevel;
+			win?.setZoomLevel(Math.min(this.ZOOM_MAX, Math.max(this.ZOOM_MIN, next)));
+		}
 	}
 }


### PR DESCRIPTION
Fixes an issue where keyboard layout could "mess up" the shortcuts for zooming in and out. The keyboard shortcut will now properly listen to `CTRL/CMD` + `+`, `-` and `0` again.