### PR TITLE
Refactor match result popup

### DIFF
--- a/src/app/modules/irc/components/irc-match-result/irc-match-result.component.ts
+++ b/src/app/modules/irc/components/irc-match-result/irc-match-result.component.ts
@@ -1,16 +1,17 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { Lobby } from '../../../../models/lobby';
 import { MultiplayerData } from '../../../../models/store-multiplayer/multiplayer-data';
 import { CacheService } from '../../../../services/cache.service';
 import { IrcService } from '../../../../services/irc.service';
-import { combineLatest, map } from 'rxjs';
+import { Observable } from 'rxjs';
+import { MatchDialogDataContextService } from '../../../../services/match-dialog-data-context.service';
 
 @Component({
 	selector: 'app-irc-match-result',
 	templateUrl: './irc-match-result.component.html',
 	styleUrl: './irc-match-result.component.scss'
 })
-export class IrcMatchResultComponent {
+export class IrcMatchResultComponent implements OnChanges {
 	@Input() selectedLobby: Lobby;
 
 	@Output() closeMatchDialogEmitter = new EventEmitter<void>();
@@ -19,22 +20,19 @@ export class IrcMatchResultComponent {
 
 	hasWon$ = this.ircService.hasWon$;
 
-	matchDialogData$ = combineLatest([
-		this.ircService.matchDialogHeaderName$,
-		this.ircService.matchDialogMultiplayerData$,
-		this.ircService.matchDialogSendFinalResult$
-	]).pipe(
-		map(([headerName, multiplayerData, sendFinalResult]) => ({
-			headerName,
-			multiplayerData,
-			sendFinalResult
-		}))
-	);
+	matchDialogData$: Observable<{ headerName: string; multiplayerData: MultiplayerData; sendFinalResult: boolean; }>;
 
 	constructor(
 		private cacheService: CacheService,
-		private ircService: IrcService
+		private ircService: IrcService,
+		private matchDialogDataContextService: MatchDialogDataContextService
 	) { }
+
+	ngOnChanges(changes: SimpleChanges): void {
+		if (changes['selectedLobby']?.currentValue) {
+			this.matchDialogData$ = this.matchDialogDataContextService.getMatchDialogData(this.selectedLobby.lobbyId);
+		}
+	}
 
 	getBeatmapName(beatmapId: number): string {
 		return this.cacheService.getBeatmapname(beatmapId);

--- a/src/app/modules/irc/components/irc/irc.component.ts
+++ b/src/app/modules/irc/components/irc/irc.component.ts
@@ -43,6 +43,7 @@ import { IrcChatControlsComponent } from '../irc-chat-controls/irc-chat-controls
 import { GenericService } from '../../../../services/generic.service';
 import { IrcLayoutService } from '../../../../services/irc-layout.service';
 import { IrcLayoutSection, IrcLayoutSectionViewType } from '../../../../models/irc-layout-section';
+import { MatchDialogDataContextService } from '../../../../services/match-dialog-data-context.service';
 
 @Component({
 	selector: 'app-irc',
@@ -129,11 +130,10 @@ export class IrcComponent implements OnInit, OnDestroy {
 		public slashCommandService: SlashCommandService,
 		public cacheService: CacheService,
 		private genericService: GenericService,
-		private ircLayoutService: IrcLayoutService) {
+		private ircLayoutService: IrcLayoutService,
+		private matchDialogDataContextService: MatchDialogDataContextService) {
 		this.currentMessageHistoryIndex = -1;
 		this.slashCommandIndex = -1;
-
-		this.ircService.matchDialogSendFinalResult$.next(false);
 
 		this.slashCommandService.registerCommand(new SlashCommand({
 			name: 'savelog',
@@ -252,14 +252,6 @@ export class IrcComponent implements OnInit, OnDestroy {
 				if (data.lobbyId == this.selectedLobby.lobbyId) {
 					this.selectedLobby = data;
 					this.refreshIrcHeader(this.selectedLobby);
-
-					if (this.selectedLobby && this.selectedLobby.hasWyBinConnected()) {
-						if (this.selectedLobby.isQualifierLobby == false) {
-							this.ircService.matchDialogHeaderName$.next('Last played beatmap');
-							this.ircService.matchDialogMultiplayerData$.next(this.selectedLobby.getLastPlayedBeatmap());
-							this.ircService.matchDialogSendFinalResult$.next(false);
-						}
-					}
 				}
 			});
 
@@ -878,27 +870,35 @@ export class IrcComponent implements OnInit, OnDestroy {
 	closeMatchDialog() {
 		if (this.selectedLobby && this.selectedLobby.hasWyBinConnected()) {
 			if (this.selectedLobby.isQualifierLobby == true) {
-				this.ircService.matchDialogHeaderName$.next(null);
-				this.ircService.matchDialogMultiplayerData$.next(null);
-				this.ircService.matchDialogSendFinalResult$.next(false);
+				this.matchDialogDataContextService.clearMatchDialogData(this.selectedLobby.lobbyId);
 			}
 			else {
-				this.ircService.matchDialogHeaderName$.next(null);
-				this.ircService.matchDialogMultiplayerData$.next(null);
-
-				if (this.ircService.hasWon$.value != null && this.ircService.matchDialogSendFinalResult$.value == false) {
-					this.ircService.matchDialogHeaderName$.next('Match has finished');
-					this.ircService.matchDialogSendFinalResult$.next(true);
+				if (this.ircService.hasWon$.value != null) {
+					this.matchDialogDataContextService.getMatchDialogData(this.selectedLobby.lobbyId)
+						.pipe(take(1))
+						.subscribe(data => {
+							if (data.sendFinalResult == false) {
+								this.matchDialogDataContextService.setMatchDialogData(
+									this.selectedLobby.lobbyId,
+									'Match has finished',
+									null,
+									true
+								);
+							}
+							else {
+								this.matchDialogDataContextService.setMatchDialogData(
+									this.selectedLobby.lobbyId,
+									null,
+									null,
+									false
+								);
+							}
+						});
 				}
 				else {
-					this.ircService.matchDialogSendFinalResult$.next(false);
+					this.matchDialogDataContextService.clearMatchDialogData(this.selectedLobby.lobbyId);
 				}
 			}
-		}
-		else {
-			this.ircService.matchDialogHeaderName$.next(null);
-			this.ircService.matchDialogMultiplayerData$.next(null);
-			this.ircService.matchDialogSendFinalResult$.next(false);
 		}
 	}
 

--- a/src/app/services/irc.service.ts
+++ b/src/app/services/irc.service.ts
@@ -10,9 +10,8 @@ import { IrcMessage } from 'app/models/irc/irc-message';
 import { WyMultiplayerLobbiesService } from './wy-multiplayer-lobbies.service';
 import { Lobby } from 'app/models/lobby';
 import { MultiplayerLobbyPlayersService } from './multiplayer-lobby-players.service';
-import { ElectronService } from './electron.service';
 import { GenericService } from './generic.service';
-import { MultiplayerData } from '../models/store-multiplayer/multiplayer-data';
+import { MatchDialogDataContextService } from './match-dialog-data-context.service';
 
 @Injectable({
 	providedIn: 'root'
@@ -49,10 +48,6 @@ export class IrcService {
 	tiebreaker$: BehaviorSubject<boolean>;
 	hasWon$: BehaviorSubject<string>;
 
-	matchDialogHeaderName$: BehaviorSubject<string>;
-	matchDialogMultiplayerData$: BehaviorSubject<MultiplayerData>;
-	matchDialogSendFinalResult$: BehaviorSubject<boolean>;
-
 	// Indicates if the multiplayerlobby is being created for "Create a lobby" route
 	isCreatingMultiplayerLobby = -1;
 
@@ -64,8 +59,8 @@ export class IrcService {
 	constructor(private toastService: ToastService,
 		private multiplayerLobbiesService: WyMultiplayerLobbiesService,
 		private multiplayerLobbyPlayersService: MultiplayerLobbyPlayersService,
-		private electronService: ElectronService,
-		private genericService: GenericService) {
+		private genericService: GenericService,
+		private matchDialogDataContextService: MatchDialogDataContextService) {
 		// Create observables for is(Dis)Connecting
 		this.isConnecting$ = new BehaviorSubject<boolean>(false);
 		this.isDisconnecting$ = new BehaviorSubject<boolean>(false);
@@ -80,10 +75,6 @@ export class IrcService {
 		this.matchPoint$ = new BehaviorSubject<string>(null);
 		this.tiebreaker$ = new BehaviorSubject<boolean>(false);
 		this.hasWon$ = new BehaviorSubject<string>(null);
-
-		this.matchDialogHeaderName$ = new BehaviorSubject<string>(null);
-		this.matchDialogMultiplayerData$ = new BehaviorSubject<MultiplayerData>(null);
-		this.matchDialogSendFinalResult$ = new BehaviorSubject<boolean>(false);
 
 		window.electronApi.osuAuthentication.getIrcCredentials().then(credentials => {
 			if (credentials.username && credentials.password) {
@@ -112,6 +103,26 @@ export class IrcService {
 				this.allChannels.push(nChannel);
 			}
 		});
+
+		this.multiplayerLobbiesService.synchronizeIsCompleted()
+			.subscribe(lobby => {
+				if (lobby == null || lobby == undefined) {
+					return;
+				}
+
+				if (!lobby.hasWyBinConnected()) {
+					return;
+				}
+
+				if (lobby.isQualifierLobby == false) {
+					this.matchDialogDataContextService.setMatchDialogData(
+						lobby.lobbyId,
+						'Last played beatmap',
+						lobby.getLastPlayedBeatmap(),
+						false
+					);
+				}
+			});
 	}
 
 	/**

--- a/src/app/services/match-dialog-data-context.service.ts
+++ b/src/app/services/match-dialog-data-context.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, combineLatest, map } from 'rxjs';
+import { MultiplayerData } from '../models/store-multiplayer/multiplayer-data';
+
+@Injectable({
+	providedIn: 'root'
+})
+export class MatchDialogDataContextService {
+	matchDialogData: {
+		[key: string]: {
+			headerName$: BehaviorSubject<string>;
+			multiplayerData$: BehaviorSubject<MultiplayerData>;
+			sendFinalResult$: BehaviorSubject<boolean>;
+		}
+	};
+
+	constructor() {
+		this.matchDialogData = {};
+	}
+
+	initializeMatchDialogData(lobbyId: number): void {
+		this.matchDialogData[lobbyId] = {
+			headerName$: new BehaviorSubject(''),
+			multiplayerData$: new BehaviorSubject(null),
+			sendFinalResult$: new BehaviorSubject(false)
+		};
+	}
+
+	getMatchDialogData(lobbyId: number): Observable<{ headerName: string; multiplayerData: MultiplayerData; sendFinalResult: boolean; }> {
+		if (!this.matchDialogData[lobbyId]) {
+			this.initializeMatchDialogData(lobbyId);
+		}
+
+		return combineLatest([
+			this.matchDialogData[lobbyId].headerName$,
+			this.matchDialogData[lobbyId].multiplayerData$,
+			this.matchDialogData[lobbyId].sendFinalResult$
+		]).pipe(
+			map(([headerName, multiplayerData, sendFinalResult]) => ({ headerName, multiplayerData, sendFinalResult }))
+		);
+	}
+
+	setMatchDialogData(lobbyId: number, headerName: string, multiplayerData: MultiplayerData, sendFinalResult: boolean): void {
+		if (!this.matchDialogData[lobbyId]) {
+			this.initializeMatchDialogData(lobbyId);
+		}
+
+		this.matchDialogData[lobbyId].headerName$.next(headerName);
+		this.matchDialogData[lobbyId].multiplayerData$.next(multiplayerData);
+		this.matchDialogData[lobbyId].sendFinalResult$.next(sendFinalResult);
+	}
+
+	clearMatchDialogData(lobbyId: number): void {
+		if (this.matchDialogData[lobbyId]) {
+			this.matchDialogData[lobbyId].headerName$.next('');
+			this.matchDialogData[lobbyId].multiplayerData$.next(null);
+			this.matchDialogData[lobbyId].sendFinalResult$.next(false);
+		}
+	}
+
+	deleteMatchDialogData(lobbyId: number): void {
+		delete this.matchDialogData[lobbyId];
+	}
+}

--- a/src/app/services/wy-multiplayer-lobbies.service.ts
+++ b/src/app/services/wy-multiplayer-lobbies.service.ts
@@ -27,6 +27,7 @@ import { WebhookService } from './webhook.service';
 import { CTMCalculation } from 'app/models/score-calculation/calculation-types/ctm-calculation';
 import { WyModBracketMap } from 'app/models/wytournament/mappool/wy-mod-bracket-map';
 import { LobbyStoreService } from './storage/lobby-store.service';
+import { MatchDialogDataContextService } from './match-dialog-data-context.service';
 
 @Injectable({
 	providedIn: 'root'
@@ -46,7 +47,8 @@ export class WyMultiplayerLobbiesService {
 		private webhookService: WebhookService,
 		private http: HttpClient,
 		private multiplayerLobbyPlayersService: MultiplayerLobbyPlayersService,
-		private lobbyStoreService: LobbyStoreService) {
+		private lobbyStoreService: LobbyStoreService,
+		private matchDialogDataContextService: MatchDialogDataContextService) {
 		this.allLobbies = [];
 		this.availableLobbyId = 0;
 
@@ -79,6 +81,8 @@ export class WyMultiplayerLobbiesService {
 						if (newLobby.lobbyId >= highestLobbyId) {
 							highestLobbyId = newLobby.lobbyId;
 						}
+
+						this.matchDialogDataContextService.initializeMatchDialogData(newLobby.lobbyId);
 					}
 
 					this.availableLobbyId = highestLobbyId + 1;
@@ -156,6 +160,7 @@ export class WyMultiplayerLobbiesService {
 	 */
 	deleteMultiplayerLobby(multiplayerLobby: Lobby): void {
 		this.allLobbies.splice(this.allLobbies.indexOf(multiplayerLobby), 1);
+		this.matchDialogDataContextService.deleteMatchDialogData(multiplayerLobby.lobbyId);
 
 		this.lobbyStoreService.deleteLobby(multiplayerLobby);
 	}


### PR DESCRIPTION
Refactors the logic of the popup that appears when a match has finished. Before it would only keep track of the current lobby you have selected, now it keeps track of every single lobby even if it is not the current focus. 