### PR TITLE
Add additional HR and DT abbreviations

### DIFF
--- a/src/app/models/osu-models/osu.ts
+++ b/src/app/models/osu-models/osu.ts
@@ -137,6 +137,8 @@ export class OsuHelper {
 			{ fullModName: 'Mixed mod', abbreviationModName: 'mm' },
 			{ fullModName: 'Mixedmod', abbreviationModName: 'mm' },
 			{ fullModName: 'Tiebreaker', abbreviationModName: 'tb' },
+			{ fullModName: 'Hard rock', abbreviationModName: 'hr' },
+			{ fullModName: 'Double time', abbreviationModName: 'dt' },
 		];
 
 		let modAbbreviations: string = null;


### PR DESCRIPTION
Adds additional abbreviations for `HardRock` and `DoubleTime`, so `Hard Rock` and `Double Time` also gets picked up as HR and DT