### PR TITLE
Irc qualifier lobby tweaks

### DIFF
--- a/src/app/modules/irc/components/irc-chat-container/irc-chat-container.component.html
+++ b/src/app/modules/irc/components/irc-chat-container/irc-chat-container.component.html
@@ -1,5 +1,5 @@
 <div class="message-container">
-	<div class="irc-match-header" *ngIf="selectedChannel?.name.startsWith('#mp_')">
+	<div class="irc-match-header" *ngIf="selectedChannel?.name.startsWith('#mp_') && selectedLobby?.isQualifierLobby != true">
 		<app-irc-match-header
 			[selectedLobby]="selectedLobby"
 			[selectedChannel]="selectedChannel"

--- a/src/app/modules/irc/components/irc-mappool/irc-mappool.component.html
+++ b/src/app/modules/irc/components/irc-mappool/irc-mappool.component.html
@@ -36,9 +36,16 @@
 					</div>
 
 					<div class="beatmap-status">
-						<div class="beatmap-status-badge" [ngClass]="{ 'beatmap-picked-team-one': beatmapIsPickedByTeamOne(selectedLobby, beatmap.beatmapId), 'beatmap-picked-team-two': beatmapIsPickedByTeamTwo(selectedLobby, beatmap.beatmapId) }">
-							Pick #{{ getPickedOrder(selectedLobby, beatmap.beatmapId) }} • {{ beatmapIsPickedByTeamOne(selectedLobby, beatmap.beatmapId) ? selectedLobby.teamOneName : selectedLobby.teamTwoName }}
-						</div>
+						@if (selectedLobby?.isQualifierLobby != true) {
+							<div class="beatmap-status-badge" [ngClass]="{ 'beatmap-picked-team-one': beatmapIsPickedByTeamOne(selectedLobby, beatmap.beatmapId), 'beatmap-picked-team-two': beatmapIsPickedByTeamTwo(selectedLobby, beatmap.beatmapId) }">
+								Pick #{{ getPickedOrder(selectedLobby, beatmap.beatmapId) }} • {{ beatmapIsPickedByTeamOne(selectedLobby, beatmap.beatmapId) ? selectedLobby.teamOneName : selectedLobby.teamTwoName }}
+							</div>
+						}
+						@else {
+							<div class="beatmap-status-badge" [ngClass]="{ 'beatmap-picked-team-one': beatmapIsPickedByTeamOne(selectedLobby, beatmap.beatmapId) || beatmapIsPickedByTeamTwo(selectedLobby, beatmap.beatmapId) }">
+								Pick #{{ getPickedOrder(selectedLobby, beatmap.beatmapId, true) }}
+							</div>
+						}
 
 						<div class="beatmap-status-badge" [ngClass]="{ 'is-banned-one': selectedLobby.beatmapIsBannedByTeamOne(beatmap.beatmapId), 'is-banned-two': selectedLobby.beatmapIsBannedByTeamTwo(beatmap.beatmapId) }">
 							Ban #{{ getBannedOrder(selectedLobby, beatmap.beatmapId) }} • {{ selectedLobby.beatmapIsBannedByTeamOne(beatmap.beatmapId) ? selectedLobby.teamOneName : selectedLobby.teamTwoName }}

--- a/src/app/modules/irc/components/irc-mappool/irc-mappool.component.ts
+++ b/src/app/modules/irc/components/irc-mappool/irc-mappool.component.ts
@@ -75,7 +75,18 @@ export class IrcMappoolComponent {
 		return multiplayerLobby.teamTwoPicks != null && multiplayerLobby.teamTwoPicks.indexOf(beatmapId) > -1;
 	}
 
-	getPickedOrder(multiplayerLobby: Lobby, beatmapId: number) {
+	getPickedOrder(multiplayerLobby: Lobby, beatmapId: number, isQualifierLobby: boolean = false) {
+		if (isQualifierLobby == true) {
+			const combinedPicks = [
+				...(multiplayerLobby.teamOnePicks ?? []),
+				...(multiplayerLobby.teamTwoPicks ?? []),
+			];
+
+			const index = combinedPicks.indexOf(beatmapId);
+
+			return index > -1 ? index + 1 : null;
+		}
+
 		const teamOneIndex = multiplayerLobby.teamOnePicks?.indexOf(beatmapId) ?? -1;
 		const teamTwoIndex = multiplayerLobby.teamTwoPicks?.indexOf(beatmapId) ?? -1;
 

--- a/src/app/modules/irc/components/irc/irc.component.html
+++ b/src/app/modules/irc/components/irc/irc.component.html
@@ -2,7 +2,7 @@
 <app-debug [data]="{ selectedChannel, selectedLobby }"></app-debug>
 
 <div class="irc">
-	<div class="first-pick-not-set" *ngIf="selectedLobby && (selectedLobby.firstPick == null || selectedLobby.bestOf == null)" (click)="openLobbyDialog()">
+	<div class="first-pick-not-set" *ngIf="selectedLobby?.isQualifierLobby != true && (selectedLobby?.firstPick == null || selectedLobby?.bestOf == null)" (click)="openLobbyDialog()">
 		You haven't set the <b>First pick</b> of the match yet. Click here to set who picks first.
 	</div>
 


### PR DESCRIPTION
- Cleans up mappool picks: no longer shows `Pick #x • Qualifier lobby`, instead just plainly shows `Pick #x` 
- Hides the `You haven't set the First pick` and `Qualifier lobby won, GG and wp!` banners