### PR TITLE
Tournament initialization refactor

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,6 +12,7 @@ import { DataMigrationDialogComponent } from './components/dialogs/data-migratio
 import { HttpErrorResponse } from '@angular/common/http';
 import { AppConfig } from '../environments/environment';
 import { NewUpdateDialogComponent } from './components/dialogs/new-update-dialog/new-update-dialog.component';
+import { TournamentService } from './services/tournament.service';
 
 @Component({
 	selector: 'app-root',
@@ -27,6 +28,7 @@ export class AppComponent implements OnInit {
 		private ircService: IrcService,
 		private authService: AuthenticateService,
 		private settingsStore: SettingsStoreService,
+		private tournamentService: TournamentService,
 		private cacheService: CacheService,
 		private dialog: MatDialog,
 		private ngZone: NgZone,
@@ -50,6 +52,8 @@ export class AppComponent implements OnInit {
 				this.versionCheckComplete = true;
 			}
 		});
+
+		this.tournamentService.loadTournaments();
 
 		this.authService.getMeData().subscribe({
 			next: user => {

--- a/src/app/modules/lobby/components/create-lobby/create-lobby.component.ts
+++ b/src/app/modules/lobby/components/create-lobby/create-lobby.component.ts
@@ -73,48 +73,51 @@ export class CreateLobbyComponent implements OnInit {
 			'selected-tournament': new FormControl(''),
 			'custom-match': new FormControl(false)
 		});
-
-		this.tournamentService.loadTournaments(false);
 	}
 
 	ngOnInit() {
-		const { tournament, match } = this.lobbyCreationContextService.getContext();
+		this.tournamentService.tournamentsHaveBeenUpdated().subscribe(updated => {
+			if (updated == true) {
+				const { tournament, match } = this.lobbyCreationContextService.getContext();
 
-		if (tournament && match) {
-			for (const findTournament of this.tournamentService.allTournaments) {
-				if (findTournament.wyBinTournamentId == tournament.id) {
-					// Delay setting the value to make sure the form has been loaded properly
-					// Otherwise it will not trigger the valueChanges observable
-					setTimeout(() => {
-						this.validationForm.get('selected-tournament').setValue(findTournament.id);
+				if (tournament && match) {
+					for (const findTournament of this.tournamentService.allTournaments) {
+						if (findTournament.wyBinTournamentId == tournament.id) {
+							// Delay setting the value to make sure the form has been loaded properly
+							// Otherwise it will not trigger the valueChanges observable
+							setTimeout(() => {
+								this.validationForm.get('selected-tournament').setValue(findTournament.id);
 
-						this.lobbyCreationContextService.getStagesLoadedObservable().subscribe(stagesLoaded => {
-							if (stagesLoaded == true) {
-								// Delay setting the value to make sure the form has been loaded properly
-								// Otherwise the matches will not be populated
-								setTimeout(() => {
-									this.validationForm.get('stage-id').setValue(match.wyBinStageId);
+								this.lobbyCreationContextService.getStagesLoadedObservable().subscribe(stagesLoaded => {
+									if (stagesLoaded == true) {
+										// Delay setting the value to make sure the form has been loaded properly
+										// Otherwise the matches will not be populated
+										setTimeout(() => {
+											this.validationForm.get('stage-id').setValue(match.wyBinStageId);
 
-									this.validationForm.get('selected-match-id').setValue(match.id);
-									this.validationForm.get('selected-match-name').setValue(match.getMatchName());
+											this.validationForm.get('selected-match-id').setValue(match.id);
+											this.validationForm.get('selected-match-name').setValue(match.getMatchName());
 
-									if (match.qualifierIdentifier == null) {
-										this.validationForm.get('team-one-name').setValue(match.opponentOne.name);
-										this.validationForm.get('team-two-name').setValue(match.opponentTwo.name);
+											if (match.qualifierIdentifier == null) {
+												this.validationForm.get('team-one-name').setValue(match.opponentOne.name);
+												this.validationForm.get('team-two-name').setValue(match.opponentTwo.name);
+											}
+											else {
+												this.validationForm.get('is-qualifier-lobby').setValue(true);
+												this.validationForm.get('qualifier-lobby-identifier').setValue(match.qualifierIdentifier);
+											}
+
+											this.lobbyCreationContextService.clear();
+										}, 1);
 									}
-									else {
-										this.validationForm.get('is-qualifier-lobby').setValue(true);
-										this.validationForm.get('qualifier-lobby-identifier').setValue(match.qualifierIdentifier);
-									}
-
-									this.lobbyCreationContextService.clear();
-								}, 1);
-							}
-						});
-					}, 1);
+								});
+							}, 1);
+						}
+					}
 				}
 			}
-		}
+		});
+
 	}
 
 	/**

--- a/src/app/services/tournament.service.ts
+++ b/src/app/services/tournament.service.ts
@@ -3,7 +3,7 @@ import { AppConfig } from '../../environments/environment';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { WyTournament } from 'app/models/wytournament/wy-tournament';
 import { Observable } from 'rxjs/internal/Observable';
-import { BehaviorSubject, filter, take } from 'rxjs';
+import { BehaviorSubject, EMPTY, catchError, filter, forkJoin, take, tap } from 'rxjs';
 import { ToastService } from './toast.service';
 import { ToastType } from 'app/models/toast';
 import { WyBinStage } from 'app/models/wybintournament/wybin-stage';
@@ -23,22 +23,26 @@ export class TournamentService {
 
 	private readonly apiUrl = AppConfig.apiUrl;
 	private tournamentsInitialized$: BehaviorSubject<boolean>;
+	private tournamentsUpdated$: BehaviorSubject<boolean>;
 
 	constructor(private tournamentStoreService: TournamentStoreService, private httpClient: HttpClient, private toastService: ToastService, private cacheService: CacheService) {
 		this.availableTournamentId = 0;
 		this.allTournaments = [];
 
 		this.tournamentsInitialized$ = new BehaviorSubject(false);
+		this.tournamentsUpdated$ = new BehaviorSubject(false);
 
-		this.loadTournaments(true);
+		this.tournamentsInitialized$.subscribe(initialized => {
+			if (initialized == true) {
+				this.updateTournaments();
+			}
+		});
 	}
 
 	/**
-	 * Load all tournaments from the store and update them if they have been updated
-	 *
-	 * @param initialLoad if this is the initial load of tournaments
+	 * Load all tournaments from the store
 	 */
-	loadTournaments(initialLoad: boolean): void {
+	loadTournaments(): void {
 		this.tournamentStoreService
 			.watchTournaments()
 			.pipe(
@@ -49,47 +53,53 @@ export class TournamentService {
 				if (tournamentStore) {
 					let highestTournamentId = 0;
 
-					// Only load in tournaments for the initial load
-					if (initialLoad == true) {
-						const tournaments = Object.values(tournamentStore);
+					const tournaments = Object.values(tournamentStore);
 
-						for (const tournament of tournaments) {
-							const newTournament = WyTournament.makeTrueCopy(tournament);
-							this.allTournaments.push(newTournament);
+					for (const tournament of tournaments) {
+						const newTournament = WyTournament.makeTrueCopy(tournament);
+						this.allTournaments.push(newTournament);
 
-							if (newTournament.id >= highestTournamentId) {
-								highestTournamentId = newTournament.id;
-							}
-						}
-
-						this.availableTournamentId = highestTournamentId + 1;
-					}
-
-					// Update tournaments if they have been updated
-					for (const tournament of this.allTournaments) {
-						if (tournament.publishId != undefined) {
-							this.getPublishedTournament(tournament.publishId).subscribe({
-								next: (data) => {
-									const publishedTournament: WyTournament = WyTournament.makeTrueCopy(data);
-
-									if (publishedTournament.updateDate.getTime() != tournament.updateDate.getTime()) {
-										publishedTournament.publishId = publishedTournament.id;
-
-										this.toastService.addToast(`The tournament "${tournament.name}" has been updated.`, ToastType.Information, 10);
-
-										this.updateTournament(publishedTournament, tournament.publishId, true);
-									}
-								},
-								error: (error: HttpErrorResponse) => {
-									console.warn(`Failed to update tournament "${tournament.name}": ${error.error.message}`);
-								}
-							});
+						if (newTournament.id >= highestTournamentId) {
+							highestTournamentId = newTournament.id;
 						}
 					}
 
-					this.tournamentsInitialized$.next(true);
+					this.availableTournamentId = highestTournamentId + 1;
 				}
+
+				this.tournamentsInitialized$.next(true);
 			});
+	}
+
+	/**
+	 * Update the tournaments if they have received an update
+	 */
+	updateTournaments() {
+		const updateRequests: Observable<WyTournament>[] = this.allTournaments
+			.filter(tournament => tournament.publishId != null)
+			.map(tournament => {
+				return this.getPublishedTournament(tournament.publishId).pipe(
+					tap(data => {
+						const publishedTournament = WyTournament.makeTrueCopy(data);
+
+						if (publishedTournament.updateDate.getTime() != tournament.updateDate.getTime()) {
+							publishedTournament.publishId = publishedTournament.id;
+
+							this.toastService.addToast(`The tournament "${tournament.name}" has been updated.`, ToastType.Information, 10);
+
+							this.updateTournament(publishedTournament, tournament.publishId, true);
+						}
+					}),
+					catchError((error: HttpErrorResponse) => {
+						console.warn(`Failed to update tournament "${tournament.name}": ${error.error.message}`);
+						return EMPTY;
+					})
+				)
+			});
+
+		forkJoin(updateRequests).subscribe(() => {
+			this.tournamentsUpdated$.next(true);
+		});
 	}
 
 	/**
@@ -97,6 +107,13 @@ export class TournamentService {
 	 */
 	tournamentsHaveBeenInitialized(): Observable<boolean> {
 		return this.tournamentsInitialized$.asObservable();
+	}
+
+	/**
+	 * Check if the tournaments have been updated
+	 */
+	tournamentsHaveBeenUpdated(): Observable<boolean> {
+		return this.tournamentsUpdated$.asObservable();
 	}
 
 	/**


### PR DESCRIPTION
- Splits up tournament loading and updating into its own separate functions
- Force tournaments update on wyReferee start
- When creating a match through wyBin schedule, it now waits for the tournaments to be updated first and then selects all relevant data